### PR TITLE
- support silero-vad-ncnn infer by cpp code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ Generate silero.jit and then convert it via the old pnnx version.
 
 - compare.py
 Compare the original jit model with the generated jit model and the ncnn model.
+
+## Cpp implementation
+- implementtion silero-vad in ncnn cpp code.
+- please modify the ncnn include/link path in CMakeLists.txt first
+- build step as follows:
+``` shell
+    cd vad-cpp
+    mkdir build && cd build
+    cmake ..
+    make -j4
+```

--- a/vad-cpp/CMakeLists.txt
+++ b/vad-cpp/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(silero-vad-ncnn)
+
+set(CMAKE_CXX_STANDARD 11)
+
+# ncnn library
+include_directories(${CMAKE_SOURCE_DIR}/../3rdParty/ncnn/include)
+link_directories(${CMAKE_SOURCE_DIR}/../3rdParty/ncnn/lib)
+
+# src files
+set(SRC_LISTS
+    ncnn_vad.cpp
+    vad_example.cpp
+)
+
+# add executable
+add_executable(silero-vad-ncnn ${SRC_LISTS})
+target_link_libraries(silero-vad-ncnn PRIVATE ncnn)

--- a/vad-cpp/ncnn_vad.cpp
+++ b/vad-cpp/ncnn_vad.cpp
@@ -1,0 +1,61 @@
+#include "ncnn_vad.h"
+
+NcnnVad::NcnnVad(const char* param_path, const char* bin_path, bool use_gpu)
+{
+    // net config
+    vad_net.opt.use_vulkan_compute = use_gpu;
+    vad_net.opt.use_fp16_packed = true;
+    vad_net.opt.use_fp16_storage = true;
+    vad_net.opt.use_fp16_arithmetic = true;
+    vad_net.opt.num_threads = 1;
+
+    // load model
+    vad_net.load_param(param_path);
+    vad_net.load_model(bin_path);    
+
+
+    // init h & c
+    h.resize(2 * 1 * 64, 0.0f);
+    c.resize(2 * 1 * 64, 0.0f);
+}
+
+
+float
+NcnnVad::infer_samples(const std::vector<float>& sample_data)
+{
+    bool is_speech = false;
+
+    // ncnn mat for input
+    ncnn::Mat in0(512, 1, 1);
+    ncnn::Mat ncnn_h(64, 1, 2);
+    ncnn::Mat ncnn_c(64, 1, 2);
+
+    // in0
+    memcpy(in0.data, sample_data.data(), 512 * sizeof(float));
+    // h & c
+    memcpy(ncnn_h.data, h.data(), h.size() * sizeof(float));
+    memcpy(ncnn_c.data, c.data(), c.size() * sizeof(float));
+
+
+    ncnn::Extractor ex = vad_net.create_extractor();
+
+    ncnn::Mat out0, out1, out2;
+    {
+        // set input
+        ex.input("in0", in0);
+        ex.input("in1", ncnn_h);
+        ex.input("in2", ncnn_c);
+
+        // get output
+        ex.extract("out0", out0);
+        ex.extract("out1", out1);
+        ex.extract("out2", out2);
+    }
+
+    // update h & c
+    memcpy(h.data(), out1.data, h.size() * sizeof(float));
+    memcpy(c.data(), out2.data, c.size() * sizeof(float));
+
+
+    return out0[0];
+}

--- a/vad-cpp/ncnn_vad.h
+++ b/vad-cpp/ncnn_vad.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ncnn/net.h"
+
+class NcnnVad {
+    public:
+        NcnnVad(const char* param_path, const char* bin_path, bool use_gpu = false);
+        ~NcnnVad(){};
+    private:
+        ncnn::Net vad_net;
+
+        // h & c
+        std::vector<float> h;
+        std::vector<float> c;
+
+    public:
+        float infer_samples(const std::vector<float>& sample_data);
+};

--- a/vad-cpp/vad_example.cpp
+++ b/vad-cpp/vad_example.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <algorithm>
+#include "ncnn_vad.h"
+#include "wav_reader.hpp"
+
+
+#define EXPECTED_SAMPLE_RATE 16000
+#define EXPECTED_CHUNK_SIZE (0.032 * EXPECTED_SAMPLE_RATE)
+
+static void normalizeSamples(const std::vector<short>& samples_short, std::vector<float>& samples_float) {
+    const float normFactor = 1.0f / 32768.0f;
+    samples_float.clear();
+    for (short sample : samples_short) {
+        samples_float.push_back(static_cast<float>(sample) * normFactor);
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc!= 4)
+    {
+        fprintf(stderr, "Usage: %s <model.param> <model.bin>  <wave_file>\n", argv[0]);
+        return -1;
+    }
+    
+
+    // create vad net
+    NcnnVad vad_net(argv[1], argv[2], false);
+
+    // Read audio data
+    int sampleRate, numSamples;
+    std::vector<short> audioData = readWAV(argv[3], sampleRate, numSamples);
+    fprintf(stderr, "Sample rate: %d\n", sampleRate);
+    fprintf(stderr, "Number of samples: %d\n", numSamples);
+
+    std::vector<float> samples_float;
+    int k = 0;
+    while (k < numSamples) {
+        
+
+        std::vector<short> samples_short(audioData.begin() + k, audioData.begin() + k + EXPECTED_CHUNK_SIZE);
+        normalizeSamples(samples_short, samples_float);
+
+        // Run inference
+        float speech_score = vad_net.infer_samples(samples_float);
+        if (speech_score > 0.5)
+        {
+            fprintf(stderr, "voice\n");
+        }
+        else
+        {
+            fprintf(stderr, "unvoice\n");
+        }
+        
+
+        
+        // k += EXPECTED_CHUNK_SIZE;
+        k = std::min(k + (int)EXPECTED_CHUNK_SIZE, numSamples);
+    }
+    
+    return 0;
+}

--- a/vad-cpp/wav_reader.hpp
+++ b/vad-cpp/wav_reader.hpp
@@ -1,0 +1,47 @@
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <cstring>
+
+// wav reader class
+struct WAVHeader {
+    char riff[4];
+    int chunkSize;
+    char wave[4];
+    char fmt[4];
+    int subchunk1Size;
+    short audioFormat;
+    short numChannels;
+    int sampleRate;
+    int byteRate;
+    short blockAlign;
+    short bitsPerSample;
+    char data[4];
+    int dataSize;
+};
+
+// read wav file and return samples
+std::vector<short> readWAV(const std::string& filename, int& sampleRate, int& numSamples) {
+    std::ifstream file(filename, std::ios::binary);
+    if (!file.is_open()) {
+        std::cerr << "can not open file " << filename << std::endl;
+        return {};
+    }
+
+    WAVHeader header;
+    file.read(reinterpret_cast<char*>(&header), sizeof(WAVHeader));
+
+    if (std::strncmp(header.riff, "RIFF", 4) != 0 || std::strncmp(header.wave, "WAVE", 4) != 0) {
+        std::cerr << "unsupported file format" << std::endl;
+        return {};
+    }
+
+    sampleRate = header.sampleRate;
+    numSamples = header.dataSize / (header.bitsPerSample / 8);
+
+    std::vector<short> samples(numSamples);
+    file.read(reinterpret_cast<char*>(samples.data()), header.dataSize);
+
+    return samples;
+}


### PR DESCRIPTION
Add the C++ implementation of silero-vad-ncnn, tested on version ncnn-20240410, and verified with the project's sample audio to ensure consistency with the test results of py-ncnn.